### PR TITLE
Update Infinispan CR to disable TLS

### DIFF
--- a/projects/harvest/display/ConsoleService.java
+++ b/projects/harvest/display/ConsoleService.java
@@ -1,4 +1,4 @@
-// camel-k: dependency=camel-infinispan dependency=camel-bean dependency=camel-jackson dependency=camel-swagger-java dependency=mvn:org.wildfly.security:wildfly-elytron:1.11.2.Final dependency=mvn:io.netty:netty-codec:4.1.49.Final configmap=shippingconsole-config trait=quarkus.enabled=false
+// camel-k: dependency=camel-infinispan dependency=camel-bean dependency=camel-jackson dependency=camel-openapi-java dependency=mvn:org.wildfly.security:wildfly-elytron:1.11.2.Final dependency=mvn:io.netty:netty-codec:4.1.49.Final configmap=shippingconsole-config trait=quarkus.enabled=false
 package module3;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.infinispan.InfinispanConstants;

--- a/projects/harvest/shipping/jdg-cluster.yaml
+++ b/projects/harvest/shipping/jdg-cluster.yaml
@@ -6,3 +6,5 @@ spec:
   replicas: 1
   security:
     endpointSecretName: connect-secret
+    endpointEncryption:
+      type: None


### PR DESCRIPTION
Update Infinispan CR to disable TLS which will cause the following error.

[1] 2022-06-21 06:35:38,458 ERROR [org.inf.HOTROD] (HotRod-client-async-pool-1-1) ISPN004007: Exception encountered. Retry 10 out of 10: org.infinispan.client.hotrod.exceptions.TransportException:: org.infinispan.client.hotrod.exceptions.TransportException:: ISPN004071: Connection to example-infinispan.user1.svc/172.30.76.32:11222 was closed while waiting for response.
[1]     at org.infinispan.client.hotrod.impl.transport.netty.ActivationHandler.exceptionCaught(ActivationHandler.java:52)
[1]     at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:302)